### PR TITLE
Add `update.eclemma.org` repository

### DIFF
--- a/otterdog/eclipse-eclemma.jsonnet
+++ b/otterdog/eclipse-eclemma.jsonnet
@@ -56,5 +56,27 @@ orgs.newOrg('eclipse-eclemma') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('update.eclemma.org') {
+      description: "website https://update.eclemma.org",
+      homepage: "https://update.eclemma.org",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_issues: false,
+      has_wiki: false,
+      has_projects: false,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "gh-pages"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
While EclEmma is available from https://download.eclipse.org/eclemma/ , some users still rely on update.eclemma.org (see for example https://groups.google.com/g/jacoco/c/AV_0CNbymA0/m/tpm-sz2YAwAJ and https://groups.google.com/g/jacoco/c/EYef2pjvn7A/m/7kXcbdTnAAAJ), whose content is hosted by @marchof in S3 AWS bucket, and which is available only by HTTP but not by HTTPS. Creation of this repository will allow us to use GitHub Pages instead and also enable HTTPS.

Once repository is created, I will publish p2 metadata to GitHub Pages, containing redirection to https://download.eclipse.org/eclemma/releases/ , and will request DNS update for update.eclemma.org